### PR TITLE
Sets receiver signature true on auction end

### DIFF
--- a/hedera-nft-auction-demo-java-node/src/main/java/com/hedera/demo/auction/node/app/App.java
+++ b/hedera-nft-auction-demo-java-node/src/main/java/com/hedera/demo/auction/node/app/App.java
@@ -89,7 +89,7 @@ public final class App {
 
     private static void startAuctionsClosureWatcher(WebClient webClient, AuctionsRepository auctionsRepository, boolean transferOnWin) {
         // start a thread to monitor auction closures
-        Thread t = new Thread(new AuctionsClosureWatcher(webClient, auctionsRepository, mirrorQueryFrequency, transferOnWin));
+        Thread t = new Thread(new AuctionsClosureWatcher(webClient, auctionsRepository, mirrorQueryFrequency, transferOnWin, refundKey));
         t.start();
     }
     private static void startSubscription(WebClient webClient, AuctionsRepository auctionsRepository, BidsRepository bidsRepository) {

--- a/hedera-nft-auction-demo-java-node/src/main/java/com/hedera/demo/auction/node/app/closurewatcher/AbstractAuctionsClosureWatcher.java
+++ b/hedera-nft-auction-demo-java-node/src/main/java/com/hedera/demo/auction/node/app/closurewatcher/AbstractAuctionsClosureWatcher.java
@@ -1,8 +1,17 @@
 package com.hedera.demo.auction.node.app.closurewatcher;
 
 import com.hedera.demo.auction.node.app.HederaClient;
+import com.hedera.demo.auction.node.app.domain.Auction;
 import com.hedera.demo.auction.node.app.repository.AuctionsRepository;
 import com.hedera.demo.auction.node.mirrormapping.MirrorTransactions;
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.AccountUpdateTransaction;
+import com.hedera.hashgraph.sdk.Client;
+import com.hedera.hashgraph.sdk.PrivateKey;
+import com.hedera.hashgraph.sdk.Status;
+import com.hedera.hashgraph.sdk.TransactionId;
+import com.hedera.hashgraph.sdk.TransactionReceipt;
+import com.hedera.hashgraph.sdk.TransactionResponse;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.WebClient;
 import lombok.extern.log4j.Log4j2;
@@ -18,16 +27,18 @@ public abstract class AbstractAuctionsClosureWatcher {
     protected final int mirrorQueryFrequency;
     protected String mirrorURL;
     protected boolean transferOnWin;
+    private final String refundKey;
 
-    protected AbstractAuctionsClosureWatcher(WebClient webClient, AuctionsRepository auctionsRepository, int mirrorQueryFrequency, boolean transferOnWin) throws Exception {
+    protected AbstractAuctionsClosureWatcher(WebClient webClient, AuctionsRepository auctionsRepository, int mirrorQueryFrequency, boolean transferOnWin, String refundKey) throws Exception {
         this.webClient = webClient;
         this.auctionsRepository = auctionsRepository;
         this.mirrorQueryFrequency = mirrorQueryFrequency;
         this.mirrorURL = HederaClient.getMirrorUrl();
         this.transferOnWin = transferOnWin;
+        this.refundKey = refundKey;
     }
 
-    void handleResponse(JsonObject response) {
+    void handleResponse(JsonObject response) throws Exception {
         if (response != null) {
             MirrorTransactions mirrorTransactions = response.mapTo(MirrorTransactions.class);
 
@@ -39,13 +50,13 @@ public abstract class AbstractAuctionsClosureWatcher {
         }
     }
 
-    protected void closeAuctionIfPastEnd(String consensusTimestamp) {
+    protected void closeAuctionIfPastEnd(String consensusTimestamp) throws Exception {
         for (Map.Entry<String, Integer> auctions : auctionsRepository.openAndPendingAuctions().entrySet()) {
             String endTimestamp = auctions.getKey();
             int auctionId = auctions.getValue();
 
             if (consensusTimestamp.compareTo(endTimestamp) > 0) {
-                // payment past auctions end, close it
+                // latest transaction past auctions end, close it
                 log.info("Closing auction id " + auctionId);
                 try {
                     if (transferOnWin) {
@@ -55,10 +66,50 @@ public abstract class AbstractAuctionsClosureWatcher {
                         // if the auction does not transfer the token on winning, set the auction to ended
                         auctionsRepository.setEnded(auctionId, "");
                     }
+                    if ( ! this.refundKey.isBlank()) {
+                        setSignatureRequiredOnAuctionAccount(auctionId);
+                    }
+
                 } catch (SQLException e) {
                     log.error(e);
                 }
             }
+        }
+    }
+
+    protected void setSignatureRequiredOnAuctionAccount(int auctionId) throws Exception {
+        Client client = HederaClient.getClient();
+
+        Auction auction = auctionsRepository.getAuction(auctionId);
+        PrivateKey refundKeyPrivate = PrivateKey.fromString(this.refundKey);
+        client.setOperator(AccountId.fromString(auction.getAuctionaccountid()), refundKeyPrivate);
+        log.info("Setting signature required key on account " + auction.getAuctionaccountid());
+
+//            //TODO: Scheduled transaction here
+//            // create a deterministic transaction id from the consensus timestamp of the payment transaction
+//            // note: this assumes the scheduled transaction occurs quickly after the payment
+//            String deterministicTxId = this.auctionAccountId.concat("@").concat(this.consensusTimestamp);
+//            TransactionId transactionId = TransactionId.fromString(deterministicTxId);
+//            // Schedule the transaction
+//            ScheduleCreateTransaction scheduleCreateTransaction = transferTransaction.schedule();
+//
+//            TransactionResponse response = scheduleCreateTransaction.execute(client);
+//            TransactionReceipt receipt = response.getReceipt(client);
+//
+
+        TransactionId transactionId = TransactionId.generate(AccountId.fromString(auction.getAuctionaccountid()));
+
+        AccountUpdateTransaction accountUpdateTransaction = new AccountUpdateTransaction();
+        accountUpdateTransaction.setTransactionId(transactionId);
+        accountUpdateTransaction.setAccountId(AccountId.fromString(auction.getAuctionaccountid()));
+        accountUpdateTransaction.setReceiverSignatureRequired(true);
+
+        TransactionResponse response = accountUpdateTransaction.execute(client);
+        // check for receipt
+        TransactionReceipt receipt = response.getReceipt(client);
+        if (receipt.status != Status.SUCCESS) {
+            log.error("Setting receiver signature required on account " + auction.getAuctionaccountid() + " failed with " + receipt.status);
+            return;
         }
     }
 }

--- a/hedera-nft-auction-demo-java-node/src/main/java/com/hedera/demo/auction/node/app/closurewatcher/AuctionsClosureWatcher.java
+++ b/hedera-nft-auction-demo-java-node/src/main/java/com/hedera/demo/auction/node/app/closurewatcher/AuctionsClosureWatcher.java
@@ -12,12 +12,14 @@ public class AuctionsClosureWatcher implements Runnable {
     private final int mirrorQueryFrequency;
     private final String mirrorProvider = HederaClient.getMirrorProvider();
     private final boolean transferOnWin;
+    private final String refundKey;
 
-    public AuctionsClosureWatcher(WebClient webClient, AuctionsRepository auctionsRepository, int mirrorQueryFrequency, boolean transferOnWin) {
+    public AuctionsClosureWatcher(WebClient webClient, AuctionsRepository auctionsRepository, int mirrorQueryFrequency, boolean transferOnWin, String refundKey) {
         this.webClient = webClient;
         this.auctionsRepository = auctionsRepository;
         this.mirrorQueryFrequency = mirrorQueryFrequency;
         this.transferOnWin = transferOnWin;
+        this.refundKey = refundKey;
     }
 
     @SneakyThrows
@@ -26,13 +28,13 @@ public class AuctionsClosureWatcher implements Runnable {
         AuctionClosureWatcherInterface auctionClosureWatcher;
         switch (mirrorProvider) {
             case "HEDERA":
-                auctionClosureWatcher = new HederaAuctionsClosureWatcher(webClient, auctionsRepository, mirrorQueryFrequency, transferOnWin);
+                auctionClosureWatcher = new HederaAuctionsClosureWatcher(webClient, auctionsRepository, mirrorQueryFrequency, transferOnWin, refundKey);
                 break;
             case "DRAGONGLASS":
-                auctionClosureWatcher = new DragonglassAuctionsClosureWatcher(webClient, auctionsRepository, mirrorQueryFrequency, transferOnWin);
+                auctionClosureWatcher = new DragonglassAuctionsClosureWatcher(webClient, auctionsRepository, mirrorQueryFrequency, transferOnWin, refundKey);
                 break;
             default:
-                auctionClosureWatcher = new KabutoAuctionsClosureWatcher(webClient, auctionsRepository, mirrorQueryFrequency, transferOnWin);
+                auctionClosureWatcher = new KabutoAuctionsClosureWatcher(webClient, auctionsRepository, mirrorQueryFrequency, transferOnWin, refundKey);
                 break;
         }
         auctionClosureWatcher.watch();

--- a/hedera-nft-auction-demo-java-node/src/main/java/com/hedera/demo/auction/node/app/closurewatcher/DragonglassAuctionsClosureWatcher.java
+++ b/hedera-nft-auction-demo-java-node/src/main/java/com/hedera/demo/auction/node/app/closurewatcher/DragonglassAuctionsClosureWatcher.java
@@ -7,8 +7,8 @@ import lombok.extern.log4j.Log4j2;
 @Log4j2
 public class DragonglassAuctionsClosureWatcher extends AbstractAuctionsClosureWatcher implements AuctionClosureWatcherInterface {
 
-    public DragonglassAuctionsClosureWatcher(WebClient webClient, AuctionsRepository auctionsRepository, int mirrorQueryFrequency, boolean transferOnWin) throws Exception {
-        super(webClient, auctionsRepository, mirrorQueryFrequency, transferOnWin);
+    public DragonglassAuctionsClosureWatcher(WebClient webClient, AuctionsRepository auctionsRepository, int mirrorQueryFrequency, boolean transferOnWin, String refundKey) throws Exception {
+        super(webClient, auctionsRepository, mirrorQueryFrequency, transferOnWin, refundKey);
     }
 
     @Override

--- a/hedera-nft-auction-demo-java-node/src/main/java/com/hedera/demo/auction/node/app/closurewatcher/HederaAuctionsClosureWatcher.java
+++ b/hedera-nft-auction-demo-java-node/src/main/java/com/hedera/demo/auction/node/app/closurewatcher/HederaAuctionsClosureWatcher.java
@@ -9,8 +9,8 @@ import lombok.extern.log4j.Log4j2;
 @Log4j2
 public class HederaAuctionsClosureWatcher extends AbstractAuctionsClosureWatcher implements AuctionClosureWatcherInterface {
 
-    public HederaAuctionsClosureWatcher(WebClient webClient, AuctionsRepository auctionsRepository, int mirrorQueryFrequency, boolean transferOnWin) throws Exception {
-        super(webClient, auctionsRepository, mirrorQueryFrequency, transferOnWin);
+    public HederaAuctionsClosureWatcher(WebClient webClient, AuctionsRepository auctionsRepository, int mirrorQueryFrequency, boolean transferOnWin, String refundKey) throws Exception {
+        super(webClient, auctionsRepository, mirrorQueryFrequency, transferOnWin, refundKey);
     }
 
     @Override
@@ -27,7 +27,7 @@ public class HederaAuctionsClosureWatcher extends AbstractAuctionsClosureWatcher
                     JsonObject body = response.result().body();
                     try {
                         handleResponse(body);
-                    } catch (RuntimeException e) {
+                    } catch (Exception e) {
                         log.error(e);
                     }
                 } else {

--- a/hedera-nft-auction-demo-java-node/src/main/java/com/hedera/demo/auction/node/app/closurewatcher/KabutoAuctionsClosureWatcher.java
+++ b/hedera-nft-auction-demo-java-node/src/main/java/com/hedera/demo/auction/node/app/closurewatcher/KabutoAuctionsClosureWatcher.java
@@ -7,8 +7,8 @@ import lombok.extern.log4j.Log4j2;
 @Log4j2
 public class KabutoAuctionsClosureWatcher extends AbstractAuctionsClosureWatcher implements AuctionClosureWatcherInterface {
 
-    public KabutoAuctionsClosureWatcher(WebClient webClient, AuctionsRepository auctionsRepository, int mirrorQueryFrequency, boolean transferOnWin) throws Exception {
-        super(webClient, auctionsRepository, mirrorQueryFrequency, transferOnWin);
+    public KabutoAuctionsClosureWatcher(WebClient webClient, AuctionsRepository auctionsRepository, int mirrorQueryFrequency, boolean transferOnWin, String refundKey) throws Exception {
+        super(webClient, auctionsRepository, mirrorQueryFrequency, transferOnWin, refundKey);
     }
 
     @Override

--- a/hedera-nft-auction-demo-java-node/src/main/java/com/hedera/demo/auction/node/app/refunder/Refunder.java
+++ b/hedera-nft-auction-demo-java-node/src/main/java/com/hedera/demo/auction/node/app/refunder/Refunder.java
@@ -48,6 +48,7 @@ public class Refunder implements Runnable {
     public void run() {
         try {
             //TODO: Check a scheduled transaction has not already completed (success) for this bid
+            // can only work with scheduled transactions
 
             // create a client for the auction's account
             Client client = HederaClient.getClient();


### PR DESCRIPTION
**Detailed description**:

The auction account is set to have its receiver signature set to true when the auction ends, this prevents further bids being sent to the account by mistake.

**Which issue(s) this PR fixes**:
Fixes #6

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
