### PR TITLE
Fix "reserve not met" and "sold" API endpoints

### DIFF
--- a/hedera-nft-auction-demo-java-node/src/main/java/com/hedera/demo/auction/app/repository/AuctionsRepository.java
+++ b/hedera-nft-auction-demo-java-node/src/main/java/com/hedera/demo/auction/app/repository/AuctionsRepository.java
@@ -180,7 +180,7 @@ public class AuctionsRepository {
     /**
      * Gets ENDED auctions with a bid above reserve
      *
-     * @return List of ENDED Auction with a bid above reserve
+     * @return List of ENDED Auction with a bid above reserve and winning bid > 0
      * @throws SQLException in the event of an error
      */
     @Nullable
@@ -188,6 +188,7 @@ public class AuctionsRepository {
         DSLContext cx = connectionManager.dsl();
         Result<Record> auctionRecords = cx.selectFrom(AUCTIONS)
                 .where(AUCTIONS.WINNINGBID.ge(AUCTIONS.RESERVE))
+                .and(AUCTIONS.WINNINGBID.ne(0L))
                 .and(AUCTIONS.STATUS.eq(Auction.ENDED))
                 .orderBy(AUCTIONS.ID)
                 .fetch();

--- a/hedera-nft-auction-demo-java-node/src/testIntegration/java/com/hedera/demo/auction/test/integration/restapi/GetAuctionsIntegrationTest.java
+++ b/hedera-nft-auction-demo-java-node/src/testIntegration/java/com/hedera/demo/auction/test/integration/restapi/GetAuctionsIntegrationTest.java
@@ -129,17 +129,24 @@ public class GetAuctionsIntegrationTest extends AbstractIntegrationTest {
 
   @Test
   public void getAuctionSold(VertxTestContext testContext) throws SQLException {
-    // reserve not met auction
+    // reserve met auction
     Auction auction = testAuctionObject(1);
-    auction.setWinningbid(2L);
+    auction.setStatus(Auction.ENDED);
+    auction.setWinningbid(6L);
     auction.setReserve(5L);
     auctionsRepository.createComplete(auction);
-    // reserve met auction
+    // ended not sold
     Auction newAuction = testAuctionObject(2);
-    newAuction.setWinningbid(2L);
+    newAuction.setWinningbid(0L);
     newAuction.setReserve(0L);
     newAuction.setStatus(Auction.ENDED);
     auctionsRepository.createComplete(newAuction);
+    // ended below reserve
+    Auction newAuction2 = testAuctionObject(3);
+    newAuction2.setWinningbid(1L);
+    newAuction2.setReserve(5L);
+    newAuction2.setStatus(Auction.ENDED);
+    auctionsRepository.createComplete(newAuction2);
 
     webClient.get(9005, "localhost", "/v1/soldauctions")
             .as(BodyCodec.buffer())
@@ -148,7 +155,7 @@ public class GetAuctionsIntegrationTest extends AbstractIntegrationTest {
               JsonArray body = new JsonArray(response.body());
               assertNotNull(body);
               assertEquals(1, body.size());
-              verifyAuction(newAuction, body.getJsonObject(0));
+              verifyAuction(auction, body.getJsonObject(0));
 
               auctionsRepository.deleteAllAuctions();
               testContext.completeNow();


### PR DESCRIPTION
Signed-off-by: Greg Scullard <gregscullard@hedera.com>

**Detailed description**:
The reserve not met api call merely returned auctions where the winning bid was below reserve, which could include auctions with no bids.
This fixes the results in that only auctions with a winning bid = 0 and a bid with a status of "reserve not met" are now returned.

**Which issue(s) this PR fixes**:
Fixes #160 
Fixes #161 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [X] Tests updated
