### PR TITLE
Non privileged user for java docker image

### DIFF
--- a/hedera-nft-auction-demo-java-node/Dockerfile
+++ b/hedera-nft-auction-demo-java-node/Dockerfile
@@ -22,6 +22,10 @@ RUN cd /opt/hedera-nft-auction-demo-java-node && ./gradlew --no-daemon assemble
 
 FROM adoptopenjdk:14-jre-hotspot
 
+RUN groupadd --gid 1000 appuser
+RUN useradd --uid 1000 --gid appuser appuser
+USER appuser
+
 RUN mkdir -p /srv
 
 # make a place to put our built JAR and copy it to there


### PR DESCRIPTION
**Detailed description**:

This change ensures that the Java Docker image doesn't run with a privileged (root) user.
The nginx, postgres and node images already implement this in their respective docker files.

**Which issue(s) this PR fixes**:
Fixes #134

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
