### PR TITLE
Check admin api key on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,14 +132,14 @@ setup the `.env` properties as follows
   
 * `MASTER_KEY=` (set only for one node which has additional authority over the auction accounts, can be the same as operator key only, else must be different)
 * `NFT_STORAGE_API_KEY=` (We use IPFS storage using [nft.storage](https://nft.storage) to store NFT metadata. You can create your API key on https://nft.storage and add it to your .env file to enable IPFS upload, this is only required if your node will be involved in token creation through the API or command line)
-* `X_API_KEY=` (API key to authenticate admin REST api calls e.g. a6e006ec-c1ac-4204-9389-8d4ad4c84a6f)
+* `X_API_KEY=` (API key to authenticate admin REST api calls e.g. a6e006ec-c1ac-4204-9389-8d4ad4c84a6f). If not set, the `ADMIN_API` variable should be set to `false`.
 
 _note: you may generate a new API key as follows, although any string will work_
 ```shell
 ./gradlew generateApiKey
 ```
 
-you may leave the other properties as is for now
+you may leave the other properties as they are for now
 
 ```shell
 cd hedera-nft-auction-demo
@@ -797,7 +797,7 @@ in addition to all node types above
 
 * `MASTER_KEY=` The ED25519 private key you generated (set only for one node which has additional authority over the auction accounts, can be the same as operator key for testing purposes only, else must be different)
 * `TRANSFER_ON_WIN=` true or false depending on whether you want the auction to transfer the tokens and winning bid automatically at the end.
-* `X_API_KEY=` (API key to authenticate admin REST api calls e.g. a6e006ec-c1ac-4204-9389-8d4ad4c84a6f)
+* `X_API_KEY=` (API key to authenticate admin REST api calls e.g. a6e006ec-c1ac-4204-9389-8d4ad4c84a6f). If not set, the `ADMIN_API` variable should be set to `false`.
 
 _note: you may generate a new API key as follows, although any string will work_
 ```shell

--- a/docker-files/.env.sample
+++ b/docker-files/.env.sample
@@ -18,7 +18,7 @@ NODE_OWNER=
 # auction topic details
 TOPIC_ID=
 
-# API key for admin functions
+# API key for admin functions, if not set, ADMIN_API variables should be set to false in docker-compose (2 locations)
 X_API_KEY=
 
 # Database information for transaction and event logging

--- a/hedera-nft-auction-demo-java-node/.env.sample
+++ b/hedera-nft-auction-demo-java-node/.env.sample
@@ -26,12 +26,11 @@ API_VERTICLE_COUNT=3
 NODE_OWNER=Hedera
 
 # Run the admin REST API true/false
+# API key for admin functions, if not set, ADMIN_API below should be set to false
+X_API_KEY=
 ADMIN_API=true
 ADMIN_API_PORT=8082
 ADMIN_API_VERTICLE_COUNT=1
-
-# API key for admin functions
-X_API_KEY=e6e006ec-c1ac-4204-9389-8d4ad4c84a6f
 
 # If a key and certificate are specified, the HTTP servers for the client and admin will run over HTTPs
 HTTPS_KEY_OR_PASS=../docker-files/key.pem

--- a/hedera-nft-auction-demo-java-node/src/main/java/com/hedera/demo/auction/app/App.java
+++ b/hedera-nft-auction-demo-java-node/src/main/java/com/hedera/demo/auction/app/App.java
@@ -166,6 +166,8 @@ public final class App {
      */
     public void runApp() throws Exception {
 
+        String apiKey = env.get("X_API_KEY");
+
         if (StringUtils.isEmpty(postgresUrl)) {
             String error = "DATABASE_URL environment variable is missing";
             log.error(error);
@@ -183,6 +185,12 @@ public final class App {
         }
         if (StringUtils.isEmpty(postgresPassword)) {
             String error = "POSTGRES_PASSWORD environment variable is missing";
+            log.error(error);
+            throw new Exception(error);
+        }
+
+        if (adminAPI && StringUtils.isEmpty(apiKey)) {
+            String error = "no X_API_KEY specified in .env, set to random string or disable admin api";
             log.error(error);
             throw new Exception(error);
         }
@@ -253,12 +261,6 @@ public final class App {
         if (adminAPI) {
             log.info("starting admin REST api");
             config.put("filesPath", filesPath);
-            String apiKey = env.get("X_API_KEY");
-            if (StringUtils.isEmpty(apiKey)) {
-                String error = "no X_API_KEY specified in .env";
-                log.error(error);
-                throw new Exception(error);
-            }
             config.put("x-api-key", apiKey);
             DeploymentOptions options = new DeploymentOptions().setConfig(config).setInstances(adminApiVerticleCount);
             vertx.deployVerticle(AdminApiVerticle.class.getName(), options);


### PR DESCRIPTION
Signed-off-by: Greg Scullard <gregscullard@hedera.com>

**Detailed description**:
An error was thrown by the app if the `X_API_KEY` was not set and  `ADMIN_API` was true. This error was thrown late in the app's startup resulting in an undefined state (the api verticle for the client rest api was still running).

The app now checks this before starting anything resulting a clean exit state which is preferable.

**Checklist**
- [X] Documentation added
- [ ] Tests updated
