### PR TITLE
redirect http to https on ports 8080 and 8081

### DIFF
--- a/docker-files/conf.d/default.conf
+++ b/docker-files/conf.d/default.conf
@@ -1,7 +1,10 @@
 server {
     listen 8080 ssl;
+
     ssl_certificate     /demo/cert.pem;
     ssl_certificate_key /demo/key.pem;
+
+    error_page 497 https://$host:8080$request_uri;
 
     location / {
         proxy_pass         http://ui:3000;
@@ -15,8 +18,11 @@ server {
 
 server {
     listen 8081 ssl;
+
     ssl_certificate     /demo/cert.pem;
     ssl_certificate_key /demo/key.pem;
+
+    error_page 497 https://$host:8081$request_uri;
 
     location / {
         proxy_pass         http://rest-api:8081;
@@ -30,6 +36,7 @@ server {
 
 server {
     listen 8082 ssl;
+
     ssl_certificate     /demo/cert.pem;
     ssl_certificate_key /demo/key.pem;
 


### PR DESCRIPTION
Signed-off-by: Greg Scullard <gregscullard@hedera.com>

**Detailed description**:
* Updates nginx configuration to redirect http to https on ports 8080 and 8080
* 8082 only supports https since it supports POST requests which should not be sent over http.

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
