### PR TITLE
Fix nginx config to properly implement http and https

### DIFF
--- a/docker-compose-compile.yaml
+++ b/docker-compose-compile.yaml
@@ -76,6 +76,7 @@ services:
     restart: unless-stopped
     ports:
       - "80:80"
+      - "443:443"
     depends_on:
       - ui
       - rest-api

--- a/docker-compose-image.yaml
+++ b/docker-compose-image.yaml
@@ -76,6 +76,7 @@ services:
     restart: unless-stopped
     ports:
       - "80:80"
+      - "443:443"
     depends_on:
       - ui
       - rest-api

--- a/docker-files/conf.d/default.conf
+++ b/docker-files/conf.d/default.conf
@@ -1,10 +1,14 @@
 server {
-    listen 80 ssl;
+    listen 80 default_server;
+    server_name _;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
 
     ssl_certificate     /demo/cert.pem;
     ssl_certificate_key /demo/key.pem;
-
-    error_page 497 https://$host:80$request_uri;
 
     location /v1/admin {
         proxy_pass         http://rest-api:8082/v1/admin;
@@ -33,37 +37,3 @@ server {
         proxy_set_header   X-Forwarded-Host $server_name;
     }
 }
-
-#server {
-#    listen 8081 ssl;
-
-#    ssl_certificate     /demo/cert.pem;
-#    ssl_certificate_key /demo/key.pem;
-
-#    error_page 497 https://$host:8081$request_uri;
-
-#    location / {
-#        proxy_pass         http://rest-api:8081;
-#        proxy_redirect     off;
-#        proxy_set_header   Host $host;
-#        proxy_set_header   X-Real-IP $remote_addr;
-#        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-#        proxy_set_header   X-Forwarded-Host $server_name;
-#    }
-#}
-
-#server {
-#    listen 8082 ssl;
-
-#    ssl_certificate     /demo/cert.pem;
-#    ssl_certificate_key /demo/key.pem;
-
-#    location / {
-#        proxy_pass         http://rest-api:8082;
-#        proxy_redirect     off;
-#        proxy_set_header   Host $host;
-#        proxy_set_header   X-Real-IP $remote_addr;
-#        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-#        proxy_set_header   X-Forwarded-Host $server_name;
-#    }
-#}


### PR DESCRIPTION
Signed-off-by: Greg Scullard <gregscullard@hedera.com>

**Detailed description**:

The nginx configuration was incorrect, requiring that `:80` was specified at the end of the url, this PR fixes this.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
